### PR TITLE
feat(register): implémentation complète de la page d'inscription

### DIFF
--- a/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/controller/AppUserController.java
+++ b/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/controller/AppUserController.java
@@ -1,6 +1,7 @@
 package com.openclassrooms.PayMyBuddyAPIWeb.controller;
 
 import com.openclassrooms.PayMyBuddyAPIWeb.dto.AppUserDTO;
+import com.openclassrooms.PayMyBuddyAPIWeb.dto.RegisterDTO;
 import com.openclassrooms.PayMyBuddyAPIWeb.service.AppUserService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,7 +44,9 @@ public class AppUserController {
     }
 
     @PostMapping
-    public ResponseEntity<AppUserDTO> createUser(@Valid @RequestBody AppUserDTO appUserDTO){
-        return ResponseEntity.ok(appUserService.createUser(appUserDTO));
+    public ResponseEntity<Void> createUser(@Valid @RequestBody RegisterDTO registerDTO){
+        return ResponseEntity.ok().build();
     }
+
+
 }

--- a/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/controller/RegisterController.java
+++ b/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/controller/RegisterController.java
@@ -1,15 +1,27 @@
 package com.openclassrooms.PayMyBuddyAPIWeb.controller;
 
 import com.openclassrooms.PayMyBuddyAPIWeb.dto.RegisterDTO;
+import com.openclassrooms.PayMyBuddyAPIWeb.exception.EmailAlreadyUsedException;
+import com.openclassrooms.PayMyBuddyAPIWeb.exception.UsernameAlreadyUsedException;
+import com.openclassrooms.PayMyBuddyAPIWeb.service.AppUserService;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @Slf4j
 @Controller
 public class RegisterController {
 
+    @Autowired
+    private AppUserService appUserService;
+
+    // GET /register : afficher le formulaire
     @GetMapping("/register")
     public String showRegisterForm(Model model) {
         log.info("********** Obtenir la page de : INSCRIPTION **********");
@@ -18,4 +30,43 @@ public class RegisterController {
     }
 
 
+    // POST /register : traitement du formulaire
+    @PostMapping("/register")
+    public String registerUser(@Valid RegisterDTO registerDTO,
+                               BindingResult bindingResult,
+                               Model model) {
+        log.info("********** POST /register : tentative d'inscription **********");
+
+        if (bindingResult.hasErrors()) {
+            log.info("Formulaire invalide, renvoi vers register.html avec affichage des erreurs");
+            return "register";
+        }
+
+        try {
+            appUserService.createUser(registerDTO); // logique pour créer l'utilisateur
+        } catch (EmailAlreadyUsedException | UsernameAlreadyUsedException e) {
+            log.debug("Exception lors de la création de l'utilisateur : {}", e.getMessage());
+
+            // déterminer le champ en erreur
+            String field = e instanceof EmailAlreadyUsedException ? "email" : "userName";
+            String fieldValue = e instanceof EmailAlreadyUsedException ? registerDTO.getEmail() : registerDTO.getUserName();
+
+            // ajouter une erreur personnalisée à BindingResult
+            bindingResult.addError(new FieldError(
+                    "registerDTO",
+                    field,
+                    fieldValue,
+                    false,
+                    new String[]{"error.registerDTO"},
+                    null,
+                    e.getMessage()
+            ));
+
+            return "register"; // renvoyer sur le formulaire avec message d'erreur
+        }
+
+        log.info("Utilisateur créé avec succès, redirection vers /login");
+        return "redirect:/login?registered";
+    }
 }
+

--- a/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/controller/RegisterController.java
+++ b/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/controller/RegisterController.java
@@ -1,0 +1,21 @@
+package com.openclassrooms.PayMyBuddyAPIWeb.controller;
+
+import com.openclassrooms.PayMyBuddyAPIWeb.dto.RegisterDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Slf4j
+@Controller
+public class RegisterController {
+
+    @GetMapping("/register")
+    public String showRegisterForm(Model model) {
+        log.info("********** Obtenir la page de : INSCRIPTION **********");
+        model.addAttribute("registerDTO", new RegisterDTO());
+        return "register"; // correspond à register.html dans src/main/resources/templates
+    }
+
+
+}

--- a/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/dto/RegisterDTO.java
+++ b/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/dto/RegisterDTO.java
@@ -1,0 +1,31 @@
+package com.openclassrooms.PayMyBuddyAPIWeb.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterDTO {
+
+    @NotBlank(message = "Le nom d'utilisateur est obligatoire")
+    @Size(max = 50, message = "Le nom d'utilisateur ne doit pas dépasser 50 caractères")
+    private String userName;
+
+    @NotEmpty(message = "Votre email ne doit pas être vide !")
+    @Email(message = "Votre email doit être valide")
+    private String email;
+
+    @NotEmpty(message = "Votre mot de passe ne doit pas être vide !")
+    @Size(min = 10, message = "Votre mdp doit contenir au minimum 10 caractères")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{10,}$",
+            message = "Le mot de passe doit contenir au moins 1 majuscule, 1 minuscule, 1 chiffre et 1 caractère spécial"
+    )
+    private String password;
+
+}

--- a/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/exception/UsernameAlreadyUsedException.java
+++ b/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/exception/UsernameAlreadyUsedException.java
@@ -1,0 +1,7 @@
+package com.openclassrooms.PayMyBuddyAPIWeb.exception;
+
+public class UsernameAlreadyUsedException  extends RuntimeException{
+    public UsernameAlreadyUsedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/service/AppUserService.java
+++ b/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/service/AppUserService.java
@@ -1,14 +1,17 @@
 package com.openclassrooms.PayMyBuddyAPIWeb.service;
 
 import com.openclassrooms.PayMyBuddyAPIWeb.dto.AppUserDTO;
+import com.openclassrooms.PayMyBuddyAPIWeb.dto.RegisterDTO;
 import com.openclassrooms.PayMyBuddyAPIWeb.entity.AppUser;
 import com.openclassrooms.PayMyBuddyAPIWeb.exception.EmailAlreadyUsedException;
 import com.openclassrooms.PayMyBuddyAPIWeb.exception.UserNotFoundException;
+import com.openclassrooms.PayMyBuddyAPIWeb.exception.UsernameAlreadyUsedException;
 import com.openclassrooms.PayMyBuddyAPIWeb.repository.AppUserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -29,33 +32,49 @@ public class AppUserService {
         }
     }
 
-    public List<AppUserDTO> getAllUsers(){
+    //Vérifier si username existe déjà
+    private void validateUserNameUnique(String userName) {
+        if (appUserRepository.findByUserName(userName).isPresent()) {
+            throw new UsernameAlreadyUsedException("Nom d'utilisateur déjà utilisé !");
+        }
+    }
+
+    public List<AppUserDTO> getAllUsers() {
         return ((List<AppUser>) appUserRepository.findAll())
                 .stream()  // Transforme la liste en Stream
                 .map(this::convertToDTO) // Convertit chaque AppUser en AppUserDTO
                 .collect(Collectors.toList()); // Re-transforme en List
     }
 
-    public Optional<AppUserDTO> getUserById(int id){
+    public Optional<AppUserDTO> getUserById(int id) {
         return appUserRepository.findById(id)
                 .map(this::convertToDTO);
     }
 
-    public Optional<AppUserDTO> getUserByUserName(String name){
+    public Optional<AppUserDTO> getUserByUserName(String name) {
         return appUserRepository.findByUserName(name)
                 .map(this::convertToDTO);
     }
 
-    public Optional<AppUserDTO> getUserByEmail(String email){
+    public Optional<AppUserDTO> getUserByEmail(String email) {
         return appUserRepository.findByEmail(email)
                 .map(this::convertToDTO);
     }
 
-    public AppUserDTO createUser(AppUserDTO appUserDTO){
-        validateEmailUnique(appUserDTO.getEmail());
-        // Sauvegarder le nouvel utilisateur après hashage du mpt de passe
-        appUserDTO.setPassword(passwordEncoder.encode(appUserDTO.getPassword()));
-        return convertToDTO(appUserRepository.save(convertToEntity(appUserDTO)));
+    public void createUser(RegisterDTO registerDTO) {
+
+        validateEmailUnique(registerDTO.getEmail());
+        validateUserNameUnique(registerDTO.getUserName());
+
+        // Sauvegarder le nouvel utilisateur après hachage du mot de passe
+        AppUser newUser = new AppUser();
+        newUser.setUserName(registerDTO.getUserName());
+        newUser.setEmail(registerDTO.getEmail());
+        newUser.setPassword(passwordEncoder.encode(registerDTO.getPassword()));
+        newUser.setBalance(BigDecimal.ZERO); // Initialisation solde à zéro pour un nouvel utilisateur
+
+        appUserRepository.save(newUser);
+
     }
 
     public AppUserDTO updateUser(int userId, AppUserDTO appUserDTO) {
@@ -80,7 +99,7 @@ public class AppUserService {
         return convertToDTO(appUserRepository.save(existingUser));
     }
 
-    public AppUserDTO convertToDTO(AppUser appUser){
+    public AppUserDTO convertToDTO(AppUser appUser) {
         return new AppUserDTO(
                 appUser.getUserId(),
                 appUser.getUserName(),
@@ -92,16 +111,5 @@ public class AppUserService {
 
     }
 
-    public AppUser convertToEntity(AppUserDTO appUserDTO){
-        return new AppUser(
-                appUserDTO.getUserId(),
-                appUserDTO.getUserName(),
-                appUserDTO.getEmail(),
-                appUserDTO.getPassword(),
-                appUserDTO.getBalance(),
-                appUserDTO.getUserCreatedAt(),
-                null
-        );
 
-    }
 }

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="fr" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>PayMyBuddy - Inscription</title>
+    <style>
+        body {
+          font-family: Open Sans, sans-serif;
+          background-color: #f8f9fa;
+          margin: 0;
+          padding: 0;
+        }
+
+        .register-card {
+          max-width: 400px;
+          margin: 5rem auto;
+          padding: 2rem 3rem;
+          border-radius: 1rem;
+          box-shadow: 0 0 15px rgba(0,0,0,0.1);
+          background: #fff;
+          display: flex; /* ici on crée un conteneur flexbox*/
+          flex-direction: column; /* les éléments dans le conteneur en colonne pour avoir le H2 et les input les uns en dessous des autres */
+          align-items: center; /* et là on les centre comme sur la maquette */
+        }
+
+        .register-card h2 {
+          width: 214px;
+          margin: 3rem auto 1.5rem auto; /* centré + marge bas */
+          text-align: center;
+          color: #FFFFFF;
+          background: #F69F1D;
+          border-radius: 8px; /* ajout des arrondis */
+          padding: 14px 24px;
+          display: flex;
+          align-items: center;   /* centrage vertical */
+          justify-content: center; /* centrage horizontal */
+        }
+
+        input::placeholder {
+          font-weight: bold;
+          color: #828282;
+        }
+
+        label {
+          display: block;
+          margin-bottom: 0.5rem;
+          font-weight: bold;
+        }
+
+        input[type="email"],input[type="text"],
+        input[type="password"] {
+          width: 295px;
+          height: 60px;
+          padding: 12px 16px;
+          border-radius: 8px;
+          border: 1px solid #ccc;
+          box-sizing: border-box;
+          margin: 0; /* marge gérée par label */
+        }
+
+        button {
+          width: 159px;
+          height: 64px;
+          padding: 14px 24px;
+          border: none;
+          border-radius: 8px;
+          background-color: #207FEE;
+          color: white;
+          font-size: 1rem;
+          cursor: pointer;
+        }
+
+        button:hover {
+          background-color: #004085;
+        }
+
+        p {
+          text-align: center;
+          margin-top: 1rem;
+        }
+
+    /* Centrage du formulaire */
+        form {
+          display: flex;
+          flex-direction: column;
+          align-items: center; /* centre tous les enfants : inputs + bouton */
+          }
+
+    /* Premier label (contenant le premier input) */
+        form label:first-of-type {
+          margin-top: 2rem; /* espace depuis le titre */
+          margin-bottom: 0.5rem; /* petit espace vers le suivant */
+          }
+
+        /* Labels intermédiaires */
+        form label:nth-of-type(2) {
+          margin-bottom: 0.5rem;
+          }
+
+        /* Dernier label */
+        form label:last-of-type {
+          margin-bottom: 5rem; /* espace avant le bouton */
+          }
+
+        .error-message {
+          color: red;
+          text-align: center;
+          margin-bottom: 1rem;
+        }
+
+    </style>
+
+</head>
+<body>
+<div class="register-card">
+    <h2>Pay My Buddy</h2>
+
+    <!-- Message d'erreur -->
+    <div th:if="${error}" class="error-message" th:text="${error}"></div>
+
+    <form method="post" th:action="@{/register}" th:object="${registerDTO}">
+        <!-- Champ username -->
+        <label>
+            <input type="text" th:field="*{userName}" placeholder="Username" required>
+        </label>
+        <!-- Erreur username -->
+        <div th:if="${#fields.hasErrors('userName')}" th:errors="*{userName}" class="error-message"></div>
+
+        <!-- Champ email -->
+        <label>
+            <input type="email" th:field="*{email}" placeholder="Mail" required>
+        </label>
+        <!-- Erreur email -->
+        <div th:if="${#fields.hasErrors('email')}" th:errors="*{email}" class="error-message"></div>
+
+        <!-- Champ mot de passe -->
+        <label>
+            <input type="password" th:field="*{password}" placeholder="Mot de passe" required>
+        </label>
+        <!-- Erreur mot de passe -->
+        <div th:if="${#fields.hasErrors('password')}" th:errors="*{password}" class="error-message"></div>
+
+        <button type="submit">S’inscrire</button>
+    </form>
+
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/transfer.html
+++ b/src/main/resources/templates/transfer.html
@@ -2,7 +2,7 @@
 <html lang="fr" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Transfer Page</title>
+    <title>PayMyBuddy - Transfert</title>
 </head>
 <body>
     <h1>Bienvenue sur PayMyBuddy-Page de Transfert</h1>


### PR DESCRIPTION
### Création de la page d'inscription
- Ajout du template `register.html` avec le formulaire pour `username`, `email` et `mot de passe`.
- Mise en place du DTO `RegisterDTO` avec contraintes de validation (`@NotBlank`, `@Email`, etc.).
- Création de `RegisterController` pour afficher la page d’inscription.
- Intégration des messages d’erreur Thymeleaf basés sur la validation du DTO.

### Gestion des exceptions métier
- Création de `UsernameAlreadyUsedException` pour signaler un username déjà existant.
- Validation de l’unicité de l’email et du username dans `AppUserService`.
- Levée de `EmailAlreadyUsedException` ou `UsernameAlreadyUsedException` selon le cas.

### Adaptation du service et du controller
- `createUser` dans `AppUserService` adapté pour recevoir `RegisterDTO` et créer un `AppUser` avec `balance` initialisée à zéro.
- `AppUserController` adapté pour POST `/users` avec `RegisterDTO` et retour `ResponseEntity<Void>`.

### Gestion des erreurs côté formulaire
- `RegisterController` gère POST `/register` avec `BindingResult`.
- Affichage des messages d’erreur personnalisés pour `email` ou `username` déjà utilisés.
- Redirection vers `/login` après succès de l’inscription.