### PR TITLE
Amélioration des tests d'intégration Login pour une couv Spring Security à 100% et simplification du DTO LoginDTO pour future API REST

### DIFF
--- a/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/dto/LoginDTO.java
+++ b/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/dto/LoginDTO.java
@@ -3,7 +3,15 @@ package com.openclassrooms.PayMyBuddyAPIWeb.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class LoginDTO {
 
     @NotEmpty(message = "Votre email ne doit pas être vide !")
@@ -12,29 +20,4 @@ public class LoginDTO {
     @NotEmpty(message = "Votre mot de passe ne doit pas être vide !")
     @Size(min = 10, message = "Votre mdp doit contenir au minimum 10 caractères")
     private String password;
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public LoginDTO(String email, String password) {
-        this.email = email;
-        this.password = password;
-    }
-
-    // Constructeur vide (important pour Jackson)
-    public LoginDTO() {
-    }
 }

--- a/src/test/resources/data-test.sql
+++ b/src/test/resources/data-test.sql
@@ -11,16 +11,16 @@ USE paymybuddy_test;
 -- Insertion de 10 utilisateurs
 -- -----------------------------------------------------
 INSERT INTO app_user (username, email, password, balance) VALUES
-('Alice', 'alice@example.com', 'password123', 500.00),
-('Bob', 'bob@example.com', 'password123', 300.00),
-('Charlie', 'charlie@example.com', 'password123', 450.00),
-('David', 'david@example.com', 'password123', 600.00),
-('Eva', 'eva@example.com', 'password123', 350.00),
-('Frank', 'frank@example.com', 'password123', 400.00),
-('Grace', 'grace@example.com', 'password123', 700.00),
-('Hugo', 'hugo@example.com', 'password123', 200.00),
-('Ivy', 'ivy@example.com', 'password123', 550.00),
-('Jack', 'jack@example.com', 'password123', 250.00);
+('Alice', 'alice@example.com', '$2a$12$4hXK2Fkte.mPQij3HXVG.OoT78F2YrZjTiV5RpJ2rBVR/ygzZXgTW', 500.00),
+('Bob', 'bob@example.com', '$2a$12$/hq.efDQggWK5YAfVBKRQOW.lXaBTvfouq/oMR8M3GeoLSRbEZ7fC', 300.00),
+('Charlie', 'charlie@example.com', '$2a$12$/FZXzOGQX9JemoHZj8GgAeBI7hApn19AQakgrvH1cKMUV75..29Mi', 450.00),
+('David', 'david@example.com', '$2a$12$TH5tm03yRUO6TDCihLqrDu4coadZUHemkuJCanf/LfQp9FnVYZ/vW', 600.00),
+('Eva', 'eva@example.com', '$2a$12$iYYiNpa/XKYSkJ9CGH1wh.kcMhBpvlw/8hBNYW878wT2rhjGKArQS', 350.00),
+('Frank', 'frank@example.com', '$2a$12$fuNUZzxNRrOWEhuHPZuT3eIyUfGlgjKQvhiUI5EQwWQdsCWW.Huse', 400.00),
+('Grace', 'grace@example.com', '$2a$12$/x2pA1QLlKa/e1P8KtzRWOBCvFNnpl/JVR9oc8Nhup7XB4CZMGJqe', 700.00),
+('Hugo', 'hugo@example.com', '$2a$12$nBVKL4dCm3tYjuUxXQjMM.ubtC83PW/oyGaaBEvdnwcEWKNoSP.RS', 200.00),
+('Ivy', 'ivy@example.com', '$2a$12$WLOsd3u1EkuatRdD5NRrTu5UWG7vnhKTKTDc3.iR4y6.0v2Ego1Hq', 550.00),
+('Jack', 'jack@example.com', '$2a$12$LjXO2tkGY2Alpvfc0mSWGu.lKD.RUr70DNBAvnWo2wj.7/7jaOuAm', 250.00);
 COMMIT;
 
 


### PR DESCRIPTION
### Hachage des mots de passe dans la base de test
- Les mots de passe des utilisateurs de la base `paymybuddy_test` sont désormais hachés avec BCrypt.
- **Objectif** : permettre le fonctionnement des tests d’intégration Spring Security avec authentification réelle.

### Ajout de tests d’intégration pour POST /login
**Scénarios couverts :**
- Utilisateur existant avec mot de passe correct → redirection vers `/transfer`.
- Utilisateur existant avec mot de passe incorrect → redirection vers `/login`.
- Utilisateur inexistant → redirection vers `/login`.

**Impact :** ces tests permettent de couvrir à 100% la configuration de Spring Security et la `CustomUserDetailsService`.

### Refactorisation du DTO Login avec Lombok
- Réduction du code répétitif dans le DTO via génération automatique des getters, setters et constructeurs (`@Getter`, `@Setter`, `@NoArgsConstructor`, `@AllArgsConstructor`).
- **Objectif** : faciliter la maintenance du DTO Login et préparer une future exposition via API REST.
