### PR TITLE
ProfilController & Profil Page : Mise à jour, style et tests

### DIFF
--- a/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/controller/ProfilController.java
+++ b/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/controller/ProfilController.java
@@ -2,11 +2,22 @@ package com.openclassrooms.PayMyBuddyAPIWeb.controller;
 
 import com.openclassrooms.PayMyBuddyAPIWeb.dto.AppUserDTO;
 import com.openclassrooms.PayMyBuddyAPIWeb.dto.ProfilDTO;
+import com.openclassrooms.PayMyBuddyAPIWeb.exception.EmailAlreadyUsedException;
+import com.openclassrooms.PayMyBuddyAPIWeb.exception.UsernameAlreadyUsedException;
 import com.openclassrooms.PayMyBuddyAPIWeb.service.AppUserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @Controller
 public class ProfilController {
@@ -26,6 +37,51 @@ public class ProfilController {
 
         model.addAttribute("profil", profilDTO);
         return "profil"; // correspond à profil.html dans /templates
-
     }
+
+    @PostMapping("/profil")
+    public String updateProfil(@Valid @ModelAttribute("profil") ProfilDTO profilDTO,
+                               BindingResult bindingResult,
+                               HttpServletRequest request,
+                               HttpServletResponse response,
+                               Model model) {
+
+        // Si des erreurs de validation sont présentes, on renvoie le formulaire
+        if (bindingResult.hasErrors()) {
+            return "profil"; // Thymeleaf affichera les messages d'erreur
+        }
+
+        // Récupérer l'utilisateur connecté
+        AppUserDTO userDTO = appUserService.getAuthenticatedUser();
+
+        boolean passwordChanged = profilDTO.getPassword() != null && !profilDTO.getPassword().isEmpty();
+
+        // Préparer un DTO pour la mise à jour
+        AppUserDTO updatedUser = new AppUserDTO();
+        updatedUser.setUserId(userDTO.getUserId());
+        updatedUser.setUserName(profilDTO.getUsername());
+        updatedUser.setEmail(userDTO.getEmail()); // email reste inchangé
+        updatedUser.setPassword(passwordChanged ? profilDTO.getPassword() : userDTO.getPassword());
+        updatedUser.setBalance(userDTO.getBalance());
+
+        try {
+            appUserService.updateUser(userDTO.getUserId(), updatedUser);
+
+            if (passwordChanged) {
+                Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+                if (auth != null) {
+                    new SecurityContextLogoutHandler().logout(request, response, auth);
+                }
+                return "redirect:/login?passwordChanged";
+            }
+
+            model.addAttribute("successMessage", "Profil mis à jour avec succès !");
+            return "profil";
+
+        } catch (UsernameAlreadyUsedException | EmailAlreadyUsedException ex) {
+            model.addAttribute("errorMessage", ex.getMessage());
+            return "profil";
+        }
+    }
+
 }

--- a/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/service/AppUserService.java
+++ b/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/service/AppUserService.java
@@ -91,6 +91,11 @@ public class AppUserService {
             validateEmailUnique(appUserDTO.getEmail());
         }
 
+        // 2-BIS Vérifier le 'username' uniquement si l'utilisateur veut le changer
+        if (!existingUser.getUserName().equals(appUserDTO.getUserName())) {
+            validateUserNameUnique(appUserDTO.getUserName());
+        }
+
         // 3- Mettre à jour les champs
         existingUser.setUserName(appUserDTO.getUserName());
         existingUser.setEmail(appUserDTO.getEmail());
@@ -138,7 +143,7 @@ public class AppUserService {
         // Étape 5 : Ajouter la relation
         currentUser.addFriend(friend);
 
-       // Étape 6 : Sauvegarder l'utilisateur courant pour persister la relation dans la table de jointure
+        // Étape 6 : Sauvegarder l'utilisateur courant pour persister la relation dans la table de jointure
         // Comme la relation est unidirectionnelle, il suffit de sauvegarder currentUser.
         // La table de jointure sera mise à jour automatiquement.
         // Si la relation était bidirectionnelle, il faudrait aussi sauvegarder friend ou utiliser cascade pour propager.
@@ -154,8 +159,5 @@ public class AppUserService {
                 appUser.getBalance(),
                 appUser.getUserCreatedAt()
         );
-
     }
-
-
 }

--- a/src/main/resources/static/css/profil.css
+++ b/src/main/resources/static/css/profil.css
@@ -18,12 +18,14 @@ main {
     color: green;                    /* Texte vert pour succès */
     text-align: center;               /* Centrage horizontal */
     margin-bottom: 20px;              /* Espace sous le message */
+    font-weight: bold;
 }
 
 .error-message {
     color: red;                       /* Texte rouge pour erreur */
     text-align: center;               /* Centrage horizontal */
     margin-bottom: 20px;              /* Espace sous le message */
+    font-weight: bold;
 }
 
 /* 3. Formulaire */
@@ -98,4 +100,21 @@ input {
 
 button:hover {
     background: #ec9a25;               /* Couleur orange plus claire au survol */
+}
+
+.input-container {
+    display: flex;
+    flex-direction: column; /* empile l’input et le message */
+     width: 277px;
+}
+
+.input-container input {
+    height: 28px;
+    font-size: 20px;
+}
+
+input[readonly] {
+    background-color: #e9ecef;  /* gris clair */
+    color: #6c757d;             /* texte gris foncé */
+    cursor: not-allowed;        /* curseur barré au survol */
 }

--- a/src/main/resources/templates/profil.html
+++ b/src/main/resources/templates/profil.html
@@ -13,12 +13,17 @@
 
 <main>
 
+    <!-- Messages globaux succès / erreur -->
+    <div th:if="${successMessage}" class="success-message" th:text="${successMessage}"></div>
+    <div th:if="${errorMessage}" class="error-message" th:text="${errorMessage}"></div>
+
     <form th:object="${profil}" method="post" th:action="@{/profil}">
 
         <!-- Champ username -->
         <div class="form-row">
             <label for="username">User Name</label>
             <input type="text" id="username" th:field="*{username}" placeholder="@username  >" required>
+            <div class="error-message" th:if="${#fields.hasErrors('username')}" th:errors="*{username}"></div>
         </div>
 
         <!-- Champ email (not updatable / readonly) -->
@@ -30,7 +35,11 @@
         <!-- Champ mot de passe + Bouton modifier-->
         <div class="form-row password-row">
             <label for="password">Mot de passe</label>
-            <input type="password" id="password" th:field="*{password}" placeholder="mot de passe           >" required>
+            <div class="input-container">
+                <input type="password" id="password" th:field="*{password}" placeholder="mot de passe           >"
+                       required>
+                <div class="error-message" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></div>
+            </div>
             <button type="submit">Modifier</button>
         </div>
 


### PR DESCRIPTION
Cette PR apporte plusieurs améliorations et compléments concernant la page **profil** et son **controller**.

### 1. Backend – AppUserService
**feat(appUserService): vérifier l'unicité du 'username' dans updateUser**
- Empêche l'enregistrement si le username est déjà utilisé.
- Utilisé notamment pour la page profil.

### 2. Frontend – Style et HTML
**style(profil): messages d'erreur et succès visibles, email readonly**
- Messages de succès et d'erreur en gras.
- Champ email grisé et curseur interdit (readonly).
- Conteneur `input-container` pour aligner input et message d'erreur.

**refactor(profil.html): réorganisation du formulaire profil**
- Ajout d’un conteneur `input-container` autour du champ mot de passe et son message d’erreur.
- Meilleure structuration du formulaire pour aligner inputs et messages d’erreur.

### 3. Backend – ProfilController
**feat(profil): ajouter la mise à jour du profil utilisateur**
- `@PostMapping("/profil")` pour modifier username et mot de passe.
- Gestion des exceptions `UsernameAlreadyUsedException` et `EmailAlreadyUsedException`.
- Déconnexion automatique si le mot de passe est modifié.
- Affichage des messages de succès et d’erreur dans la vue.

### 4. Tests d’intégration
**test(profil): compléter avec des tests POST pour ProfilController**
- Scénarios testés :
  - POST /profil sans changement de mot de passe → username mis à jour, email inchangé, message de succès affiché.
  - POST /profil avec erreurs de validation → BindingResult contient les erreurs, vue renvoyée.
  - POST /profil avec changement de mot de passe → redirection vers `/login?passwordChanged` et vérification du mot de passe.
  - POST /profil avec username déjà utilisé → exception capturée, message d’erreur affiché.
- Tous les tests utilisent `@WithMockUser` et CSRF.
- Transactions rollbackées automatiquement pour isoler les tests.
