### PR TITLE
Améliorations build, service et tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>**/*IT.java</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
             <!-- Maven Failsafe Plugin configuration for running integration tests (*IT.java) -->
             <plugin>
@@ -150,10 +158,16 @@
                 <executions>
                     <execution>
                         <id>integration-test</id>
+                        <phase>integration-test</phase>
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/*IT.java</include>
+                            </includes>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/service/AppUserService.java
+++ b/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/service/AppUserService.java
@@ -9,6 +9,7 @@ import com.openclassrooms.PayMyBuddyAPIWeb.exception.EmailAlreadyUsedException;
 import com.openclassrooms.PayMyBuddyAPIWeb.exception.UserNotFoundException;
 import com.openclassrooms.PayMyBuddyAPIWeb.exception.UsernameAlreadyUsedException;
 import com.openclassrooms.PayMyBuddyAPIWeb.repository.AppUserRepository;
+import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,8 +18,6 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 public class AppUserService {
@@ -41,28 +40,6 @@ public class AppUserService {
         if (appUserRepository.findByUserName(userName).isPresent()) {
             throw new UsernameAlreadyUsedException("Nom d'utilisateur déjà utilisé !");
         }
-    }
-
-    public List<AppUserDTO> getAllUsers() {
-        return appUserRepository.findAll()
-                .stream()  // Transforme la liste en Stream
-                .map(this::convertToDTO) // Convertit chaque AppUser en AppUserDTO
-                .collect(Collectors.toList()); // Re-transforme en List
-    }
-
-    public Optional<AppUserDTO> getUserById(int id) {
-        return appUserRepository.findById(id)
-                .map(this::convertToDTO);
-    }
-
-    public Optional<AppUserDTO> getUserByUserName(String name) {
-        return appUserRepository.findByUserName(name)
-                .map(this::convertToDTO);
-    }
-
-    public Optional<AppUserDTO> getUserByEmail(String email) {
-        return appUserRepository.findByEmail(email)
-                .map(this::convertToDTO);
     }
 
     public void createUser(RegisterDTO registerDTO) {
@@ -118,6 +95,7 @@ public class AppUserService {
                 ));
     }
 
+    @Transactional
     public void addFriendByEmail(String friendEmail) {
         // Étape 1 : Récupérer l'utilisateur courant connecté
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();


### PR DESCRIPTION
### Build
**chore(build): configuration surefire/failsafe pour séparer unit et IT**
- `surefire` exécute **/*Test.java** (tests unitaires rapides)
- `failsafe` exécute **/*IT.java** (tests d'intégration)

### Service
**fix(service): ajout de @Transactional sur addFriendByEmail**
- évite `LazyInitializationException` sur la collection `friends` en gardant la session Hibernate ouverte pendant l’ajout d’un ami
- permet ainsi de persister correctement la relation `friends` dans la base
- suppression des méthodes obsolètes de la classe `AppUserService` non utilisées dans le projet 

### Tests
**test: refactor des tests RegisterControllerIT et RelationControllerIT**
- utilisation du `AppUserService` réel au lieu du mock
- permet de vérifier que les données sont réellement persistées dans la base
- améliore la couverture Jacoco en testant le service réel
