### PR TITLE
Refactor addFriendByEmail pour éviter LazyInitializationException

### DIFF
--- a/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/repository/AppUserRepository.java
+++ b/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/repository/AppUserRepository.java
@@ -2,6 +2,8 @@ package com.openclassrooms.PayMyBuddyAPIWeb.repository;
 
 import com.openclassrooms.PayMyBuddyAPIWeb.entity.AppUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -38,4 +40,17 @@ public interface AppUserRepository extends JpaRepository<AppUser, Integer> {
      * @return un Optional contenant l'utilisateur si trouvé, sinon vide
      */
     Optional<AppUser> findByUserName(String userName);
+
+    /**
+     * Recherche un utilisateur par son adresse email et charge simultanément sa liste d'amis.
+     * <p>
+     * Utilise un LEFT JOIN FETCH sur la relation friends afin d'initialiser la collection dès la récupération
+     * de l'utilisateur, évitant ainsi les problèmes de LazyInitializationException lorsque la session Hibernate est fermée.
+     * </p>
+     *
+     * @param email l'email de l'utilisateur à rechercher
+     * @return un Optional contenant l'utilisateur avec sa collection d'amis préchargée si trouvé, sinon vide
+     */
+    @Query("SELECT u FROM AppUser u LEFT JOIN FETCH u.friends WHERE u.email = :email")
+    Optional<AppUser> findByEmailWithFriends(@Param("email") String email);
 }

--- a/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/service/AppUserService.java
+++ b/src/main/java/com/openclassrooms/PayMyBuddyAPIWeb/service/AppUserService.java
@@ -180,10 +180,12 @@ public class AppUserService {
      * @throws IllegalArgumentException si l'utilisateur tente de s'ajouter lui-même
      * @throws IllegalStateException si la relation existe déjà
      */
-    @Transactional
+
     public void addFriendByEmail(String friendEmail) {
-        // Étape 1 : Récupérer l'utilisateur courant connecté
-        AppUser currentUser = getAuthenticatedUserEntity();
+        // Étape 1 : Récupérer l'utilisateur courant connecté avec ses amis
+        AppUser currentUser = appUserRepository.findByEmailWithFriends(getAuthenticatedUserEntity().getEmail())
+                .orElseThrow(() -> new AuthenticatedUserNotFoundException("Utilisateur connecté introuvable"));
+
 
         // Étape 2 : Vérifier si l'ami existe en BDD
         AppUser friend = appUserRepository.findByEmail(friendEmail)


### PR DESCRIPTION
- **Ajout de la méthode `findByEmailWithFriends` dans `AppUserRepository`**  
  Permet d’effectuer un `LEFT JOIN FETCH` sur `friends` lors de la récupération par email, afin de précharger la liste des amis.

- **Adaptation de l'accès à la collection `friends` dans `addFriendByEmail`**  
  Utilisation de `AppUserRepository.findByEmailWithFriends()` pour éviter les `LazyInitializationException`.

- **Suppression de l'annotation `@Transactional` sur `AppUserService.addFriendByEmail`**  
  Non nécessaire pour cette opération simple d’ajout d’ami.

- **Maintien de la logique métier**  
  Validation de l’existence de l’ami, prévention de l’auto-ajout et des doublons avant persistance.

- **Mise à jour du test d’intégration `RelationControllerIT.postRelation_duplicateFriend_shouldRedirectWithBindingError`**  
  Recharge de l’utilisateur courant **avec ses amis** depuis la BDD après l’appel du service pour vérifier la persistance et éviter l’accès à une collection détachée.
